### PR TITLE
add sicp.el pseudo-library

### DIFF
--- a/sicp.el
+++ b/sicp.el
@@ -1,0 +1,35 @@
+;;; sicp.el --- Structure and Interpretation of Computer Programs in info format
+
+;;; Copyright (C) 1993  Hal Abelson, Jerry Sussman, and Julie Sussman
+
+;; Author: Hal Abelson
+;;	Jerry Sussman
+;;	Julie Sussman
+;; Homepage: https://mitpress.mit.edu/sicp
+
+;; This file is not part of GNU Emacs.
+
+;; This file is distributed under the Creative Commons
+;; Attribution-ShareAlike 4.0 International Public License
+;; See http://creativecommons.org/licenses/by-sa/4.0/
+;; and http://creativecommons.org/licenses/by-sa/4.0/legalcode.
+
+;;; Commentary:
+
+;; The second edition of the book Structure and Interpretation of
+;; Computer Programs (SICP) in info format.
+
+;; This library provides the feature `sicp' and does nothing else.
+;; This allows making the info file available on Melpa.  The texi
+;; file was taken from http://www.neilvandyke.org/sicp-texi.  The
+;; html version can be found at https://mitpress.mit.edu/sicp.
+
+;; If you want to recreate the info file, you can do so using
+;;
+;;   makeinfo –no-split sicp.texi -o sicp.info
+
+;;; Code:
+
+(provide 'sicp)
+
+;;; sicp.el ends here


### PR DESCRIPTION
This allows Melpa to extract and display information about the package, which should make it more discoverable.

cc @purcell
