### PR TITLE
Adjust elisp license to GPLv3, fixes #6

### DIFF
--- a/sicp.el
+++ b/sicp.el
@@ -9,10 +9,25 @@
 
 ;; This file is not part of GNU Emacs.
 
-;; This file is distributed under the Creative Commons
-;; Attribution-ShareAlike 4.0 International Public License
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;; The included sicp.info and sicp.texi files reatain their
+;; origin Creative Commons Attribution-ShareAlike 4.0
+;; International Public License
 ;; See http://creativecommons.org/licenses/by-sa/4.0/
 ;; and http://creativecommons.org/licenses/by-sa/4.0/legalcode.
+
 
 ;;; Commentary:
 


### PR DESCRIPTION
For license compatibility with MELPA and Emacs plugins: https://www.gnu.org/licenses/gpl-faq.html#GPLPlugins

Original content contained in .texi and generated .info file is already CC licensed and can not be re-licensed by me. This CC license remains unchanged and is also noted in .el comments..