### PR TITLE
Fixed incorrect equation in Ex 2.56.

### DIFF
--- a/sicp.el
+++ b/sicp.el
@@ -41,7 +41,7 @@
 
 ;; If you want to recreate the info file, you can do so using
 ;;
-;;   makeinfo –no-split sicp.texi -o sicp.info
+;;   makeinfo -–no-split sicp.texi -o sicp.info
 
 ;;; Code:
 

--- a/sicp.texi
+++ b/sicp.texi
@@ -9118,9 +9118,9 @@ differentiator to handle more kinds of expressions.  For instance, implement
 the differentiation rule
 
 @example
-n_1   n_2
---- = ---  if and only if n_1 d_2 = n_2 d_1
-d_1   d_2
+d(u^n)             / du \
+------ = n u^(n-1) | -- |
+  dx               \ dx /
 @end example
 
 @noindent


### PR DESCRIPTION
In this TeXinfo version, the first exercise in the symbolic differentiation example incorrectly asks the reader to add the following differentiation rule to the algorithm:

        n_1   n_2
        --- = ---  if and only if n_1 d_2 = n_2 d_1
        d_1   d_2

This is not a differentiation rule and is clearly not the equation that was meant, as is confirmed by referring to the original text of SICP.  The rest of the question makes no sense in light of this equation.  This PR replaces the equation the correct one:

        d(u^n)             / du \
        ------ = n u^(n-1) | -- |
          dx               \ dx /

It also includes a small typo fix for the build instructions in sicp.el.